### PR TITLE
lazily-initialise surroundings ivar

### DIFF
--- a/lib/surrounded.rb
+++ b/lib/surrounded.rb
@@ -6,23 +6,9 @@ module Surrounded
     klass.class_eval {
       extend Surrounded::Contextual
     }
-    unless klass.is_a?(Class)
-      def klass.extended(object)
-        Surrounded.create_surroundings(object)
-      end
-    end
-  end
-
-  def self.extended(object)
-    Surrounded.create_surroundings(object)
   end
 
   module Contextual
-    def new(*args)
-      instance = super
-      Surrounded.create_surroundings(instance)
-      instance
-    end
   end
 
   def store_context(ctxt)
@@ -35,12 +21,8 @@ module Surrounded
 
   private
 
-  def self.create_surroundings(obj)
-    obj.instance_variable_set(:@__surroundings__, [])
-  end
-
   def surroundings
-    @__surroundings__
+    @__surroundings__ ||= []
   end
 
   def context


### PR DESCRIPTION
Hey there. I've got a rails app using Mongoid and Active Model Serializers. When I `include Surrounded` to my `Mongoid::Document`, and AMS tries to figure out whether it wants to serialize it or not, Surrounded explodes because it tries to call `surroundings.first` in `context`. For some reason, the Contextual `new` doesn't get called. This may be due to the way Mongoid creates objects, I'm not sure. Either way, if you make the surroundings array lazily initialised you can remove a lot of code. I fully expect there's some subtlety that I'm missing here, but it has stopped my exception from being raised.

What do you think?
