### PR TITLE
Cleanup argument forwarding with ruby 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1' ]
     name: Ruby ${{ matrix.ruby }} sample
     steps:
       - uses: actions/checkout@v2

--- a/lib/surrounded/context/negotiator.rb
+++ b/lib/surrounded/context/negotiator.rb
@@ -15,8 +15,8 @@ module Surrounded
           # circumvent method_missing
           mod.instance_methods(false).each do |meth|
             num = __LINE__; klass.class_eval %{
-              def #{meth}(*args, &block)
-                __behaviors__.instance_method(:#{meth}).bind(@object).call(*args, &block)
+              def #{meth}(...)
+                __behaviors__.instance_method(:#{meth}).bind(@object).call(...)
               end
             }, __FILE__, num
           end
@@ -57,8 +57,8 @@ module Surrounded
         @object = object
       end
 
-      def method_missing(meth, *args, &block)
-        @object.send(meth, *args, &block)
+      def method_missing(meth, ...)
+        @object.send(meth, ...)
       end
 
       def respond_to_missing?(meth, include_private=false)

--- a/lib/surrounded/context/role_map.rb
+++ b/lib/surrounded/context/role_map.rb
@@ -6,6 +6,8 @@ module Surrounded
       extend Forwardable
 
       class << self
+        # Get the role map container and provide an alternative if desired
+        # Ex: RoleMap.from_base(SomeCustomContainer)
         def from_base(klass=::Triad)
           unless const_defined?(:Container)
             role_mapper = Class.new(self)

--- a/lib/surrounded/context/trigger_controls.rb
+++ b/lib/surrounded/context/trigger_controls.rb
@@ -54,7 +54,7 @@ module Surrounded
 
       def define_trigger(name)
         line = __LINE__; self.class_eval %{
-          def #{name}(*args, &block)
+          def #{name}(...)
             begin
               apply_behaviors
 
@@ -71,7 +71,7 @@ module Surrounded
         if method_defined?(name)
           %{super}
         else
-          %{self.send("__trigger_#{name}", *args, &block)}
+          %{self.send("__trigger_#{name}", ...)}
         end
       end
       

--- a/lib/surrounded/version.rb
+++ b/lib/surrounded/version.rb
@@ -1,5 +1,5 @@
 module Surrounded
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 
   def self.version
     VERSION

--- a/test/role_context_method_test.rb
+++ b/test/role_context_method_test.rb
@@ -53,10 +53,34 @@ describe Surrounded::Context, '.role' do
       def hello
         'hello from admin'
       end
+
+      def splat_args(*args)
+        args
+      end
+
+      def keyword_args(**kwargs)
+        kwargs
+      end
+
+      def mixed_args(*args, **kwargs)
+        [args, kwargs]
+      end
     end
  
     trigger :admin_hello do
       admin.hello
+    end
+
+    trigger :splat_args do |*args|
+      admin.splat_args(*args)
+    end
+
+    trigger :keyword_args do |**kwargs|
+      admin.keyword_args(**kwargs)
+    end
+
+    trigger :mixed_args do |*args, **kwargs|
+      admin.mixed_args(*args, **kwargs)
     end
   end
  
@@ -84,6 +108,18 @@ describe Surrounded::Context, '.role' do
  
     it 'creates a private accessor method' do
       assert context.respond_to?(:admin, true)
+    end
+
+    it 'works with multiple args' do
+      assert_equal context.splat_args("one", "two"), %w[ one two ]
+    end
+
+    it 'works with multiple keyword args' do
+      assert_equal context.keyword_args(one: "one", two: "two"), { one: "one", two: "two" }
+    end
+
+    it 'works with multiple mixed args' do
+      assert_equal context.mixed_args("one", :two, three: "three", four: "four"), [["one", :two], { three: "three", four: "four" }]
     end
   end
  

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 require 'simplecov'
 require 'minitest/autorun'
-SimpleCov.start
+SimpleCov.start unless defined?(Coverage)
 
 require 'surrounded'
 require 'surrounded/context'


### PR DESCRIPTION
Rely on ruby 2.7 `...` to forward arguments.
Drop support for lower versions.