### PR TITLE
Resolve role players by object identity (fix wrapper schizophrenia)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v5

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "minitest"
+gem "minitest-mock"
 gem "simplecov"
 gem "casting"
 gem "async"

--- a/lib/surrounded/context.rb
+++ b/lib/surrounded/context.rb
@@ -96,7 +96,7 @@ module Surrounded
       def role?(name, &block)
         return false unless role_map.role?(name)
         accessor = block.binding.eval("self")
-        role_map.role_player?(accessor) && role_map.assigned_player(name)
+        role_map.role_player?(accessor) && role_map.current_player(name)
       end
 
       # Check if a given object is a role player in the context.
@@ -153,7 +153,6 @@ module Surrounded
       end
 
       def map_role(role, mod_name, object)
-        instance_variable_set("@#{role}", object)
         role_map.update(role, role_module_basename(mod_name), object)
       end
 
@@ -168,7 +167,6 @@ module Surrounded
           end
 
           role_player = applicator.call(role_const(behavior), object)
-          map_role(role, behavior, role_player)
         end
         role_player || object
       end
@@ -206,6 +204,7 @@ module Surrounded
       def apply_behaviors
         role_map.each do |role, mod_name, object|
           player = apply_behavior(role, mod_name, object)
+          role_map.apply(role, player)
           if player.respond_to?(:store_context, true)
             player.__send__(:store_context) {}
           end
@@ -213,12 +212,14 @@ module Surrounded
       end
 
       def remove_behaviors
-        role_map.each do |role, mod_name, player|
+        role_map.each do |role, mod_name, object|
+          player = role_map.current_player(role)
           if player.respond_to?(:remove_context, true)
             player.__send__(:remove_context) {}
           end
           remove_behavior(role, mod_name, player)
         end
+        role_map.reset_applied
       end
 
       # List of possible methods to use to add behavior to an object from a module.
@@ -284,8 +285,8 @@ module Surrounded
           .to_s
           .split("_")
           .map { |part|
-          part.capitalize
-        }
+            part.capitalize
+          }
           .join
           .sub(/_\d+/, "") + suffix.to_s
       end

--- a/lib/surrounded/context/role_builders.rb
+++ b/lib/surrounded/context/role_builders.rb
@@ -46,11 +46,8 @@ module Surrounded
       # Create an object which will bind methods to the role player.
       #
       # This object will behave differently that a wrapper or delegate_class.
-      # The interface object should only be used for objects whose methods
-      # _will not_ call to the other objects in the context.
-      # Because the interface methods are applied individually to an object,
-      # that object is unaware of the other objects in the context and cannot
-      # access them from any of its methods.
+      # Interface methods run as the wrapped object itself, so they can access
+      # the other objects in the context only if that object includes Surrounded.
       def interface(name, &block)
         # AdminInterface
         interface_name = RoleName(name, "Interface")

--- a/lib/surrounded/context/role_map.rb
+++ b/lib/surrounded/context/role_map.rb
@@ -32,16 +32,40 @@ module Surrounded
         keys.include?(role)
       end
 
-      # Check if an object is playing a role in this map
-      def role_player?(object)
-        !values(object).empty?
-      rescue container.class::ItemNotPresent
-        false
+      # Record the behaviored player applied to a role for the duration of a
+      # trigger. The assigned domain object stays in the container; the player
+      # (a wrapper, or the same object for cast roles) is tracked here.
+      def apply(role, player)
+        applied[role] = player
       end
 
-      # Get the object playing the given role
+      # The player a role currently presents: the applied player while a trigger
+      # is running, otherwise the assigned domain object.
+      def current_player(role)
+        applied.fetch(role) { assigned_player(role) }
+      end
+
+      # Forget all applied players, e.g. after a trigger removes behaviors.
+      def reset_applied
+        applied.clear
+      end
+
+      # Check if an object is playing a role in this map, by identity — whether
+      # it is the assigned domain object or the applied player wrapping it.
+      def role_player?(object)
+        values.any? { |player| player.equal?(object) } ||
+          applied.values.any? { |player| player.equal?(object) }
+      end
+
+      # Get the domain object assigned to the given role
       def assigned_player(role)
         values(role).first
+      end
+
+      private
+
+      def applied
+        @applied ||= {}
       end
     end
   end

--- a/lib/surrounded/context/seclusion.rb
+++ b/lib/surrounded/context/seclusion.rb
@@ -10,10 +10,16 @@ module Surrounded
         const
       end
 
-      # Create attr_reader for the named methods and make them private
+      # Create readers for the named methods and make them private. Role names
+      # resolve to the current player (original object, or its applied wrapper
+      # during a trigger); any other name reads its instance variable.
       def private_attr_reader(*method_names)
-        attr_reader(*method_names)
-        private(*method_names)
+        method_names.each do |name|
+          define_method(name) do
+            role_map.role?(name) ? role_map.current_player(name) : instance_variable_get(:"@#{name}")
+          end
+          private(name)
+        end
       end
     end
   end

--- a/test/role_identity_test.rb
+++ b/test/role_identity_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+# Refuses value-equality so resolution must use object identity.
+class IdentityResistant
+  include Surrounded
+
+  def initialize(name)
+    @name = name
+  end
+  attr_reader :name
+
+  def ==(other) = false
+  def eql?(other) = false
+  def hash = object_id
+end
+
+class SpeakerContext
+  extend Surrounded::Context
+
+  initialize :speaker, :listener
+
+  interface :speaker do
+    def greet
+      listener.name
+    end
+  end
+
+  trigger :speak do
+    speaker.greet
+  end
+end
+
+describe "role identity independent of equality" do
+  it "resolves a sibling role by object identity, not ==" do
+    a = IdentityResistant.new("A")
+    b = IdentityResistant.new("B")
+    expect(SpeakerContext.new(speaker: a, listener: b).speak).must_equal "B"
+  end
+end


### PR DESCRIPTION
While I was poking around in here I hit a case where an interface role couldn't reach another role in the context. It raised a NameError even though the other player was sitting right there.

Here's what was going on. When behaviors get applied during a trigger, the role map was having its stored object overwritten with the wrapper. So when something asked "is this object playing a role?", we were comparing the bare object against its wrapper. Those come out equal one direction but not the other (the wrapper forwards == to the object, but the plain object has no idea about the wrapper), and triad's value index does a hash lookup that misses it. It's the old object schizophrenia thing, where a player is really two objects, the domain object and its wrapper.

So I split the two jobs apart. The role map now only holds the actual objects you passed in, which is the identity we care about for "who's playing what". RoleMap keeps track of the applied wrappers separately for the life of a trigger and clears them afterward. role_player? compares by identity against either the assigned object or the applied wrapper, so it no longer leans on == behaving a particular way. Accessors and sibling lookups go through whichever player is current. I also moved that bookkeeping out of the context and into RoleMap, since keeping track of role players is really RoleMap's job and not the context's.

There's a new test that casts a role player whose == always returns false, so it only passes if we're genuinely comparing identity.

A few smaller things came along for the ride: added minitest-mock to the Gemfile (minitest 6 split mock out into its own gem and one of the existing tests requires it), added 4.0 to the CI matrix, and fixed a comment on the interface role type that claimed interface methods can't reach other roles. They can, as long as the object includes Surrounded.
